### PR TITLE
Revive EndsWithConsonant for backward compatibility

### DIFF
--- a/hangul.go
+++ b/hangul.go
@@ -72,6 +72,19 @@ func SplitCompat(c rune) (l, m, t rune) {
 	return
 }
 
+// EndsWithConsonant returns true if the given word ends with
+// consonant(종성), false otherwise.
+//
+// ```
+// a := hangul.EndsWithConsonant("강")
+// // a = true
+// b := hangul.EndsWithConsonant("물고기")
+// // b = false
+// ```
+func EndsWithConsonant(word string) bool {
+	return LastConsonant(word) != 0
+}
+
 // LastConsonant returns true if the given word ends with
 // consonant(종성), false otherwise.
 //

--- a/hangul_test.go
+++ b/hangul_test.go
@@ -151,6 +151,30 @@ func TestJamoConstants(t *testing.T) {
 	}
 }
 
+func TestEndsWithConsonant(t *testing.T) {
+	cases := []struct {
+		word     string
+		endsWith bool
+	}{
+		{"", false},
+		{"강", true},
+		{"그날맑", true},
+		{"이", false},
+		{"물고기", false},
+	}
+	for _, c := range cases {
+		if EndsWithConsonant(c.word) != c.endsWith {
+			if c.endsWith {
+				t.Errorf("'%s' should be ends with consonant",
+					c.word)
+			} else {
+				t.Errorf("'%s' should not be ends with consonant",
+					c.word)
+			}
+		}
+	}
+}
+
 func TestLastConsonant(t *testing.T) {
 	cases := []struct {
 		word     string


### PR DESCRIPTION
Now `EndsWithConsonant` is obsolete due to `LastConsonant` but some libraries which depend on `go_hangul` may still require it. Also, we still can find it in `README`. So for backward compatibility, it should remain.